### PR TITLE
Misskey互換のrotate構文を追加

### DIFF
--- a/src/client/components/mfm.functions.ts
+++ b/src/client/components/mfm.functions.ts
@@ -110,13 +110,13 @@ export const mfmFunctions: Record<string, MfmFunctionDefinition> = {
 	},
 	rotate: {
 		props: {
-			angle: genProp(ts._mfmpad._functions.angle, ts._mfmpad._functions.rotateAngleDescription),
+			deg: genProp(ts._mfmpad._functions.angle, ts._mfmpad._functions.rotateAngleDescription),
 			x: genFlagProp(ts._mfmpad._functions.xspin),
 			y: genFlagProp(ts._mfmpad._functions.yspin),
 		},
 		style: args => {
 			const f = args.x ? 'perspective(128px) rotateX' : args.y ? 'perspective(128px) rotateY' : 'rotate';
-			return `transform: ${f}(${args.angle || '90'}deg); transform-origin: center center`;
+			return `transform: ${f}(${args.deg || args.angle || '90'}deg); transform-origin: center center`;
 		},
 		noAnimatedMfmStyle: true,
 		isGroundpolisExtension: true,

--- a/src/client/pages/mfm-cheat-sheet.vue
+++ b/src/client/pages/mfm-cheat-sheet.vue
@@ -60,9 +60,9 @@ export default defineComponent({
 				[ 'bounce', `$[bounce 🍮]` ],
 				[ 'shake', `$[shake 🍮]` ],
 				[ 'twitch', `$[twitch 🍮]` ],
-				[ 'spin', `$[spin 🍮] [spin.left 🍮] [spin.alternate 🍮]\n[spin.x 🍮] [spin.x,left 🍮] [spin.x,alternate 🍮]\n[spin.y 🍮] [spin.y,left 🍮] [spin.y,alternate 🍮]` ],
-				[ 'flip', `$[flip ${this.$ts._mfm.dummy}]\n[flip.v ${this.$ts._mfm.dummy}]\n[flip.h,v ${this.$ts._mfm.dummy}]` ],
-				[ 'rotate', `$[rotate.y,angle=-20 ${this.$ts._mfm.dummy}]` ],
+				[ 'spin', `$[spin 🍮] $[spin.left 🍮] $[spin.alternate 🍮]\n$[spin.x 🍮] $[spin.x,left 🍮] $[spin.x,alternate 🍮]\n$[spin.y 🍮] $[spin.y,left 🍮] $[spin.y,alternate 🍮]` ],
+				[ 'flip', `$[flip ${this.$ts._mfm.dummy}]\n$[flip.v ${this.$ts._mfm.dummy}]\n$[flip.h,v ${this.$ts._mfm.dummy}]` ],
+				[ 'rotate', `$[rotate.y,deg=340 ${this.$ts._mfm.dummy}]` ],
 				[ 'font', `$[font.size=48px,color=red ${this.$ts._mfm.dummy}]` ],
 			]),
 		}


### PR DESCRIPTION
## Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
misskey v12.98.0 で$[rotate]構文が追加された。(`rotate.x`や`rotate.y`オプションは追加されていない)
ただ、角度調節方法がgroundpolisの`rotate.angle`と違い`rotate.deg`なのでそれを追加した。
互換性のためにrotate.angleは残しておいた。