### PR TITLE
fix: Change the database name in docker_example.env to the default one

### DIFF
--- a/.config/docker_example.env
+++ b/.config/docker_example.env
@@ -1,4 +1,4 @@
 # db settings
 POSTGRES_PASSWORD=example-misskey-pass
 POSTGRES_USER=example-misskey-user
-POSTGRES_DB=misskey
+POSTGRES_DB=groundpolis


### PR DESCRIPTION
Fixes #407